### PR TITLE
Add Task Bug

### DIFF
--- a/StrideLearningApp/View/CollectionView.swift
+++ b/StrideLearningApp/View/CollectionView.swift
@@ -58,6 +58,9 @@ class CollectionView: UIViewController, UICollectionViewDataSource, UICollection
         weekView.delegate = self
         weekView.dataSource = self
         
+        weekday = "Monday"
+        week = "last-week"
+        
     }
     
         override func viewWillAppear(_ animated: Bool) {
@@ -222,7 +225,7 @@ class CollectionView: UIViewController, UICollectionViewDataSource, UICollection
             print("You selected " + self.week)
             
         })
-        let cancelAction=UIAlertAction(title: "Cancel", style: .default, handler: nil)
+        let cancelAction=UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
 
         alert.addAction(okAction)
         okAction.isEnabled = false


### PR DESCRIPTION
- Fixed bug where task wouldn't add when it started on Monday and Last Week
- Switched buttons around so that Cancel is on left and Add is on right